### PR TITLE
chore: upgrade actions/create-github-app-token to v3, use client-id

### DIFF
--- a/.github/workflows/enforce-github-pat-expiration.yml
+++ b/.github/workflows/enforce-github-pat-expiration.yml
@@ -8,10 +8,10 @@ jobs:
   check-pats:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/create-github-app-token@v1
+    - uses: actions/create-github-app-token@v3
       id: app-token
       with:
-        app-id: ${{ vars.APP_ID }} # use a PAT with `admin:org` permissions or a GitHub app token
+        client-id: ${{ vars.APP_CLIENT_ID }} # use a PAT with `admin:org` permissions or a GitHub app token
         private-key: ${{ secrets.PRIVATE_KEY }}
         owner: joshjohanning-org-saml # ${{ github.repository_owner }}
     - name: Check and Revoke PATs


### PR DESCRIPTION
## Summary

Upgrades `actions/create-github-app-token` to `@v3` and migrates from the deprecated `app-id` input to `client-id`.

### Changes
- ⬆️ Updated `actions/create-github-app-token` to `@v3`
- 🔄 Renamed input from `app-id` to `client-id` ([v3 changelog](https://github.com/actions/create-github-app-token/releases/tag/v3.0.0))
- 📝 Renamed variable references to use `*_CLIENT_ID` naming

### ✅ Variable Updates
- New variable(s) created: `APP_CLIENT_ID`
- Workflow updated to reference the new variable(s)

### 🧹 After Merging
Delete the old variable(s) that are no longer referenced: `APP_ID`