### PR TITLE
chore: rename secret PRIVATE_KEY to APP_PRIVATE_KEY

### DIFF
--- a/.github/workflows/enforce-github-pat-expiration.yml
+++ b/.github/workflows/enforce-github-pat-expiration.yml
@@ -12,7 +12,7 @@ jobs:
       id: app-token
       with:
         client-id: ${{ vars.APP_CLIENT_ID }} # use a PAT with `admin:org` permissions or a GitHub app token
-        private-key: ${{ secrets.PRIVATE_KEY }}
+        private-key: ${{ secrets.APP_PRIVATE_KEY }}
         owner: joshjohanning-org-saml # ${{ github.repository_owner }}
     - name: Check and Revoke PATs
       uses: joshjohanning/enforce-github-pat-expiration@v1


### PR DESCRIPTION
## Summary

Renames secret references from `secrets.PRIVATE_KEY` to `secrets.APP_PRIVATE_KEY` for consistency across all repos.

### ⚠️ Before Merging
1. Create a new secret `APP_PRIVATE_KEY` with the same value as `PRIVATE_KEY`
2. Then merge this PR
3. Delete the old `PRIVATE_KEY` secret